### PR TITLE
Display Errors and List Caching

### DIFF
--- a/CampusCompass/AvailableBuildingsList.swift
+++ b/CampusCompass/AvailableBuildingsList.swift
@@ -72,7 +72,6 @@ struct AvailableBuildingsList: View {
                 }
                 .task {
                     await network.fetchBuildings(campus: store.selectedSchoolInternalName)
-                    network.clearFeatureCache()
                 }
             }
         }

--- a/CampusCompass/AvailableBuildingsList.swift
+++ b/CampusCompass/AvailableBuildingsList.swift
@@ -67,8 +67,8 @@ struct AvailableBuildingsList: View {
                         }
                     }
                 }
-                .onAppear {
-                    network.fetchBuildings(campus: store.selectedSchoolInternalName)
+                .task {
+                    await network.fetchBuildings(campus: store.selectedSchoolInternalName)
                 }
             }
         }

--- a/CampusCompass/AvailableBuildingsList.swift
+++ b/CampusCompass/AvailableBuildingsList.swift
@@ -71,7 +71,9 @@ struct AvailableBuildingsList: View {
                     }
                 }
                 .task {
-                    await network.fetchBuildings(campus: store.selectedSchoolInternalName)
+                    if network.buildings.isEmpty {
+                        await network.fetchBuildings(campus: store.selectedSchoolInternalName)
+                    }
                 }
             }
         }

--- a/CampusCompass/AvailableBuildingsList.swift
+++ b/CampusCompass/AvailableBuildingsList.swift
@@ -72,6 +72,7 @@ struct AvailableBuildingsList: View {
                 }
                 .task {
                     await network.fetchBuildings(campus: store.selectedSchoolInternalName)
+                    network.clearFeatureCache()
                 }
             }
         }

--- a/CampusCompass/AvailableFeaturesList.swift
+++ b/CampusCompass/AvailableFeaturesList.swift
@@ -77,7 +77,9 @@ struct AvailableFeaturesList: View {
                 }
             }
             .task {
-                await network.fetchFeatures(building: store.selectedBuildingInternalName)
+                if network.features.isEmpty {
+                    await network.fetchFeatures(building: store.selectedBuildingInternalName)
+                }
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/CampusCompass/AvailableFeaturesList.swift
+++ b/CampusCompass/AvailableFeaturesList.swift
@@ -74,8 +74,8 @@ struct AvailableFeaturesList: View {
                     }
                 }
             }
-            .onAppear {
-                network.fetchFeatures(building: store.selectedBuildingInternalName)
+            .task {
+                await network.fetchFeatures(building: store.selectedBuildingInternalName)
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/CampusCompass/AvailableSchoolsList.swift
+++ b/CampusCompass/AvailableSchoolsList.swift
@@ -9,8 +9,11 @@ import SwiftUI
 
 struct AvailableSchoolsList: View {
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
+    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var store: Store
     @EnvironmentObject var network: Network
+    
+    @State var errorState: Bool = false
     
     var body: some View {
         NavigationStack {
@@ -75,6 +78,29 @@ struct AvailableSchoolsList: View {
             }
         }
         .navigationBarBackButtonHidden(true)
+        .onChange(of: network.loadError) { newValue in
+            self.errorState = newValue != nil
+        }
+        // Error handling
+        .alert("Error", isPresented: $errorState, presenting: network.loadError) { error in
+            Button {
+                Task {
+                    await network.fetchCampuses()
+                    // Set it to nil so that this will reappear if the error happens again
+                    network.loadError = nil
+                }
+            } label: {
+                Text("Try Again")
+            }
+            Button {
+                network.loadError = nil
+                dismiss()
+            } label: {
+                Text("OK")
+            }
+        } message: { error in
+            Text(error.description)
+        }
     }
 }
 

--- a/CampusCompass/AvailableSchoolsList.swift
+++ b/CampusCompass/AvailableSchoolsList.swift
@@ -68,8 +68,8 @@ struct AvailableSchoolsList: View {
                             }
                         }
                     }
-                    .onAppear {
-                        network.fetchCampuses()
+                    .task {
+                        await network.fetchCampuses()
                     }
                 }
             }

--- a/CampusCompass/AvailableSchoolsList.swift
+++ b/CampusCompass/AvailableSchoolsList.swift
@@ -72,7 +72,9 @@ struct AvailableSchoolsList: View {
                         }
                     }
                     .task {
-                        await network.fetchCampuses()
+                        if network.schools.isEmpty {
+                            await network.fetchCampuses()
+                        }
                     }
                 }
             }

--- a/CampusCompass/BuildingSearchScreen.swift
+++ b/CampusCompass/BuildingSearchScreen.swift
@@ -11,6 +11,7 @@ struct BuildingSearchScreen: View {
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject var store: Store
+    @EnvironmentObject var network: Network
     
     var body: some View {
         
@@ -110,6 +111,9 @@ struct BuildingSearchScreen: View {
             }
         }
         .navigationBarBackButtonHidden(true)
+        .onChange(of: store.selectedSchoolInternalName) { _ in
+            network.clearBuildingCache()
+        }
     }
 }
 

--- a/CampusCompass/LocationSelectionScreen.swift
+++ b/CampusCompass/LocationSelectionScreen.swift
@@ -191,6 +191,7 @@ struct LocationSelectionScreen: View {
         }
         .onChange(of: store.selectedBuildingInternalName) { _ in
             network.route = []
+            network.clearFeatureCache()
         }
     }
 }

--- a/CampusCompass/RouteLogic/Network.swift
+++ b/CampusCompass/RouteLogic/Network.swift
@@ -66,7 +66,7 @@ class Network: ObservableObject {
         }.resume()
     }
     
-    func fetchFeatures(building: String) {
+    func fetchFeatures(building: String) async {
         guard let url = URL(string: "http://\(IP):8000/features/\(building)")
         else {
             return
@@ -106,7 +106,7 @@ class Network: ObservableObject {
         }.resume()
     }
     
-    func fetchBuildings(campus: String) {
+    func fetchBuildings(campus: String) async {
         guard let url = URL(string: "http://\(IP):8000/buildings/\(campus)")
         else {
             return
@@ -145,7 +145,7 @@ class Network: ObservableObject {
         }.resume()
     }
     
-    func fetchCampuses() {
+    func fetchCampuses() async {
         guard let url = URL(string: "http://\(IP):8000/campus")
         else {
             return

--- a/CampusCompass/RouteLogic/Network.swift
+++ b/CampusCompass/RouteLogic/Network.swift
@@ -188,6 +188,10 @@ class Network: ObservableObject {
         self.features = []
     }
     
+    func clearBuildingCache() {
+        self.buildings = []
+    }
+    
     // Error reporting functions
     private func reportNoConnect() {
         DispatchQueue.main.async {

--- a/CampusCompass/RouteLogic/Network.swift
+++ b/CampusCompass/RouteLogic/Network.swift
@@ -184,6 +184,11 @@ class Network: ObservableObject {
         }.resume()
     }
     
+    func clearFeatureCache() {
+        self.features = []
+    }
+    
+    // Error reporting functions
     private func reportNoConnect() {
         DispatchQueue.main.async {
             self.loadError = .unableToConnect

--- a/CampusCompass/RouteLogic/Network.swift
+++ b/CampusCompass/RouteLogic/Network.swift
@@ -14,6 +14,8 @@ class Network: ObservableObject {
     @Published var buildings: Array<Building> = []
     @Published var schools: Array<School> = []
     
+    @Published var loadError: LoadError? = nil
+    
     // IP Address of services to connect to
     private let IP: String = "192.168.1.83"
     
@@ -39,6 +41,7 @@ class Network: ObservableObject {
             (data, response, error) in
             if let error = error {
                 print(error)
+                self.reportNoConnect()
                 return
             }
             
@@ -49,6 +52,7 @@ class Network: ObservableObject {
                     return
                 }
                 DispatchQueue.main.async {
+                    self.loadError = nil
                     let substringRoute = String(decoding: data, as: UTF8.self)
                     let substringArray = substringRoute.split(whereSeparator: \.isNewline)
                     self.route = substringArray.map { (Substring) -> String in
@@ -56,6 +60,8 @@ class Network: ObservableObject {
                     }
                 }
                 
+            } else {
+                self.reportError(errorCode: response.statusCode)
             }
         }.resume()
     }
@@ -72,6 +78,7 @@ class Network: ObservableObject {
             (data, response, error) in
             if let error = error {
                 print(error)
+                self.reportNoConnect()
                 return
             }
             
@@ -82,6 +89,7 @@ class Network: ObservableObject {
                     return
                 }
                 DispatchQueue.main.async {
+                    self.loadError = nil
                     do {
                         let decodedFeatures = try JSONDecoder().decode([FeatureMessage].self, from: data)
                         self.features = decodedFeatures.map {
@@ -92,6 +100,8 @@ class Network: ObservableObject {
                     }
                 }
                 
+            } else {
+                self.reportError(errorCode: response.statusCode)
             }
         }.resume()
     }
@@ -108,6 +118,7 @@ class Network: ObservableObject {
             (data, response, error) in
             if let error = error {
                 print(error)
+                self.reportNoConnect()
                 return
             }
             
@@ -128,6 +139,8 @@ class Network: ObservableObject {
                     }
                 }
                 
+            } else {
+                self.reportError(errorCode: response.statusCode)
             }
         }.resume()
     }
@@ -144,6 +157,7 @@ class Network: ObservableObject {
             (data, response, error) in
             if let error = error {
                 print(error)
+                self.reportNoConnect()
                 return
             }
             
@@ -164,8 +178,29 @@ class Network: ObservableObject {
                     }
                 }
                 
+            } else {
+                self.reportError(errorCode: response.statusCode)
             }
         }.resume()
+    }
+    
+    private func reportNoConnect() {
+        DispatchQueue.main.async {
+            self.loadError = .unableToConnect
+        }
+    }
+    
+    private func reportError(errorCode: Int) {
+        DispatchQueue.main.async {
+            switch errorCode {
+            case 500:
+                self.loadError = .internalServerError
+            case 404:
+                self.loadError = .notFoundError
+            default:
+                self.loadError = .unknownError
+            }
+        }
     }
 
     struct RouteMessage: Codable {
@@ -194,4 +229,23 @@ class Network: ObservableObject {
         let internal_name: String
     }
 
+}
+
+enum LoadError {
+    case internalServerError
+    case unableToConnect
+    case notFoundError
+    case unknownError
+    var description: String {
+        switch self {
+        case .internalServerError:
+            return "Sorry, there was an error on our end 😨"
+        case .unableToConnect:
+            return "It appears you lack a connection or our servers are down.\n Please try again later."
+        case .notFoundError:
+            return "It appears that we can't find an entry in our server for your request.\n Please report this to the CampusCompass Team."
+        case .unknownError:
+            return "Unknown error. Please report to the CampusCompass Team."
+        }
+    }
 }


### PR DESCRIPTION
This PR displays errors that occur when communicating with the APIs.
It gives the user the chance to try again, or simply go back and escape the screen.

I also implemented caching, so we no longer call the API unless we actually need new data. For instance, if you go to the buildings list, select one, go to the next page, lose connection, and go back to buildings, the buildings will still be there. This reduces the number of calls we make to the API and makes the experience smoother if the connection drops intermittently.

Resolves #8.